### PR TITLE
Bulk Reindexing

### DIFF
--- a/src/Base/Indexer.php
+++ b/src/Base/Indexer.php
@@ -32,40 +32,5 @@ abstract class Indexer implements \Suilven\FreeTextSearch\Interfaces\Indexer
     }
 
 
-    /**
-     * Get the indexable fields for a given dataobject as an array
-     *
-     * @param \SilverStripe\ORM\DataObject $dataObject get the indexable fields for the provided data object
-     * @return array<string>
-     */
-    protected function getFieldsToIndex(DataObject $dataObject): array
-    {
-        $indexes = new Indexes();
-        $indices = $indexes->getIndexes();
 
-        $payload = [];
-
-        /** @var \Suilven\FreeTextSearch\Index $indice */
-        foreach ($indices as $indice) {
-            $indicePayload = [];
-
-            $clazz = $indice->getClass();
-            $classes = $dataObject->getClassAncestry();
-
-            foreach ($classes as $indiceClass) {
-                if ($indiceClass !== $clazz) {
-                    continue;
-                }
-
-                $fields = $indice->getFields();
-                foreach ($fields as $field) {
-                    $value = $dataObject->$field;
-                    $indicePayload[$field] = $value;
-                }
-            }
-            $payload[$indice->getName()] = $indicePayload;
-        }
-
-        return $payload;
-    }
 }

--- a/src/Base/Searcher.php
+++ b/src/Base/Searcher.php
@@ -33,7 +33,7 @@ abstract class SearcherBase implements Searcher
     protected $hasManyTokens;
 
 
-    abstract public function search(string $q): SearchResults;
+    abstract public function search(?string $q): SearchResults;
 
 
     /** @param array<string,string|int|float> $filters */

--- a/src/Container/SearchResults.php
+++ b/src/Container/SearchResults.php
@@ -9,6 +9,8 @@
 
 namespace Suilven\FreeTextSearch\Container;
 
+use SilverStripe\ORM\ArrayList;
+
 /**
  * Class SearchResults
  *
@@ -39,6 +41,11 @@ class SearchResults
 
     /** @var float the time in seconds */
     private $time;
+
+    public function __construct()
+    {
+        $this->time = 0;
+    }
 
 
     /** @param array<string,int|bool|float|string> $newFacets */

--- a/src/Factory/BulkIndexerFactory.php
+++ b/src/Factory/BulkIndexerFactory.php
@@ -10,11 +10,12 @@
 namespace Suilven\FreeTextSearch\Factory;
 
 use SilverStripe\Core\Injector\Injector;
+use Suilven\FreeTextSearch\Interfaces\BulkIndexer;
 use Suilven\FreeTextSearch\Interfaces\Indexer;
 
 class BulkIndexerFactory
 {
-    public function getIndexer(): Indexer
+    public function getBulkIndexer(): BulkIndexer
     {
         return Injector::inst()->get('FreeTextBulkIndexerImplementation');
     }

--- a/src/Factory/BulkIndexerFactory.php
+++ b/src/Factory/BulkIndexerFactory.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Factory;
+
+use SilverStripe\Core\Injector\Injector;
+use Suilven\FreeTextSearch\Interfaces\Indexer;
+
+class BulkIndexerFactory
+{
+    public function getIndexer(): Indexer
+    {
+        return Injector::inst()->get('FreeTextBulkIndexerImplementation');
+    }
+}

--- a/src/Helper/IndexingHelper.php
+++ b/src/Helper/IndexingHelper.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Helper;
+
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\DataObject;
+use Suilven\FreeTextSearch\Indexes;
+use Suilven\FreeTextSearch\Interfaces\Indexer;
+
+class IndexingHelper
+{
+    /**
+     * Get the indexable fields for a given dataobject as an array
+     *
+     * @param \SilverStripe\ORM\DataObject $dataObject get the indexable fields for the provided data object
+     * @return array<string>
+     */
+    public function getFieldsToIndex(DataObject $dataObject): array
+    {
+        $indexes = new Indexes();
+        $indices = $indexes->getIndexes();
+
+        $payload = [];
+
+        /** @var \Suilven\FreeTextSearch\Index $indice */
+        foreach ($indices as $indice) {
+            $indicePayload = [];
+
+            $clazz = $indice->getClass();
+            $classes = $dataObject->getClassAncestry();
+
+            foreach ($classes as $indiceClass) {
+                if ($indiceClass !== $clazz) {
+                    continue;
+                }
+
+                $fields = $indice->getFields();
+                foreach ($fields as $field) {
+                    $value = $dataObject->$field;
+                    $indicePayload[$field] = $value;
+                }
+            }
+            $payload[$indice->getName()] = $indicePayload;
+        }
+
+        // @todo a possible mutator, specific to different search engines, may be required here
+
+        return $payload;
+    }
+}

--- a/src/Interfaces/BulkIndexer.php
+++ b/src/Interfaces/BulkIndexer.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Interfaces;
+
+use SilverStripe\ORM\DataObject;
+
+interface BulkIndexer
+{
+
+    /**
+     * Index a single data objecct
+     *
+     * @param \SilverStripe\ORM\DataObject $dataObject
+     */
+    public function addDataObject(DataObject $dataObject): void;
+
+    public function indexDataObjects();
+
+
+
+
+    /** @param string $newIndex the name of the index */
+    public function setIndex(string $newIndex): void;
+}

--- a/src/Interfaces/Searcher.php
+++ b/src/Interfaces/Searcher.php
@@ -48,5 +48,5 @@ interface Searcher
      * @param string $q the search query
      * @todo Fix annotation
      */
-    public function search(string $q): SearchResults;
+    public function search(?string $q): SearchResults;
 }

--- a/src/Page/SearchPage.php
+++ b/src/Page/SearchPage.php
@@ -53,6 +53,7 @@ class SearchPage extends \Page
 
     private static $defaults = [
         'IndexToSearch' => 'sitetree',
+        'ShowInsearch' => false
     ];
 
     /**

--- a/src/Task/ReindexTask.php
+++ b/src/Task/ReindexTask.php
@@ -14,7 +14,9 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
+use Suilven\FreeTextSearch\Factory\BulkIndexerFactory;
 use Suilven\FreeTextSearch\Indexes;
+use Suilven\ManticoreSearch\Service\BulkIndexer;
 
 class ReindexTask extends BuildTask
 {
@@ -48,6 +50,8 @@ class ReindexTask extends BuildTask
         $indexName = $request->getVar('index');
         $indexes = new Indexes();
         $index = $indexes->getIndex($indexName);
+
+        /** @var string $clazz */
         $clazz = $index->getClass();
 
 
@@ -58,21 +62,38 @@ class ReindexTask extends BuildTask
         $climate->border();
 
         $nDocuments = SiteTree::get()->count();
+        $bulkSize = 500; // @todo configurable
+        $pages = 1+round($nDocuments / $bulkSize);
+        $climate->green('Pages: ' . $pages);
         $climate->green()->info('Indexing ' . $nDocuments .' objects');
         $progress = $climate->progress()->total($nDocuments);
 
-        $ctr = 0;
-        foreach ($clazz::get() as $do) {
-            $do->write();
+        $factory = new BulkIndexerFactory();
+        $bulkIndexer = $factory->getBulkIndexer();
+        $bulkIndexer->setIndex($indexName);
 
-            $ctr++;
-            $progress->current($ctr);
+        for ($i = 0; $i < $pages; $i++)
+        {
+            $dataObjects = $clazz::get()->limit($bulkSize, $i*$bulkSize)->filter('ShowInSearch', true);
+            foreach($dataObjects as $do) {
+                // @hack
+                if ($do->ID !== 6) {
+                    $bulkIndexer->addDataObject($do);
+                }
+
+            }
+            $bulkIndexer->indexDataObjects();
+            $current = $bulkSize * ($i+1);
+            $progressValue = $current > $bulkSize ? $bulkSize : $current;
+            $progress->current(10);
         }
+
+
 
         $endTime = microtime(true);
         $delta = $endTime-$startTime;
 
-        $rate = round($delta / $nDocuments, 2);
+        $rate = round($bulkSize * ($delta / $pages), 2);
 
         $elapsedStr = round($delta, 2);
 
@@ -81,7 +102,7 @@ class ReindexTask extends BuildTask
         $climate->bold()->blue()->inline("{$elapsedStr}");
         $climate->blue()->inline('s, ');
         $climate->bold()->blue()->inline("{$rate}");
-        $climate->blue()->inline(' per second ');
+        $climate->blue(' per second ');
 
     }
 }

--- a/src/Task/ReindexTask.php
+++ b/src/Task/ReindexTask.php
@@ -76,7 +76,7 @@ class ReindexTask extends BuildTask
         {
             $dataObjects = $clazz::get()->limit($bulkSize, $i*$bulkSize)->filter('ShowInSearch', true);
             foreach($dataObjects as $do) {
-                // @hack
+                // @hack @todo FIX
                 if ($do->ID !== 6) {
                     $bulkIndexer->addDataObject($do);
                 }
@@ -84,8 +84,10 @@ class ReindexTask extends BuildTask
             }
             $bulkIndexer->indexDataObjects();
             $current = $bulkSize * ($i+1);
-            $progressValue = $current > $bulkSize ? $bulkSize : $current;
-            $progress->current(10);
+            if ($current > $nDocuments) {
+                $current = $nDocuments;
+            }
+            $progress->current($current);
         }
 
 
@@ -93,7 +95,7 @@ class ReindexTask extends BuildTask
         $endTime = microtime(true);
         $delta = $endTime-$startTime;
 
-        $rate = round($bulkSize * ($delta / $pages), 2);
+        $rate = round($nDocuments / $delta, 2);
 
         $elapsedStr = round($delta, 2);
 


### PR DESCRIPTION
## Description

Indexing documents one by one is slow, as such ensure the reindex task indexes in bulk

## Motivation and context

Reindexing speed.  Native manticoresearch against the database is crazy fast, indexing DataObjects one by one is crazy slow, likes of one per second.

Closes #11

