### PR TITLE
Implement Queues

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -2,7 +2,7 @@
 Name: freetextindexes-extensions
 ---
 
-SilverStripe\ORM\DataObject:
+SilverStripe\CMS\Model\SiteTree:
   extensions:
     - Suilven\FreeTextSearch\Extension\IndexingExtension
 

--- a/_config/implementation.yml
+++ b/_config/implementation.yml
@@ -1,0 +1,7 @@
+---
+Name: implementation-freetext
+---
+
+SilverStripe\Core\Injector\Injector:
+  FreeTextIndexablePayloadMutatorImplementation:
+    class: Suilven\FreeTextSearch\Implementation\IdentityIndexablePayloadMutator

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "php": "~7",
-        "silverstripe\/cms": "^4"
+        "silverstripe/cms": "^4",
+        "symbiote/silverstripe-queuedjobs": "^4.5"
     },
     "require-dev": {
         "ergebnis\/composer-normalize": "^2.5",

--- a/src/Base/Indexer.php
+++ b/src/Base/Indexer.php
@@ -10,6 +10,7 @@
 namespace Suilven\FreeTextSearch\Base;
 
 use SilverStripe\ORM\DataObject;
+use Suilven\FreeTextSearch\Helper\IndexingHelper;
 
 abstract class Indexer implements \Suilven\FreeTextSearch\Interfaces\Indexer
 {
@@ -26,5 +27,16 @@ abstract class Indexer implements \Suilven\FreeTextSearch\Interfaces\Indexer
     public function setIndex(string $newIndex): void
     {
         $this->index = $newIndex;
+    }
+
+    /**
+     * @param \SilverStripe\ORM\DataObject $dataObject
+     * @return array
+     */
+    protected function getIndexablePayload(\SilverStripe\ORM\DataObject $dataObject): array
+    {
+        $helper = new IndexingHelper();
+        $payload = $helper->getFieldsToIndex($dataObject);
+        return $payload;
     }
 }

--- a/src/Container/SearchResults.php
+++ b/src/Container/SearchResults.php
@@ -39,12 +39,15 @@ class SearchResults
     /** @var \SilverStripe\ORM\ArrayList */
     private $records;
 
+    private $suggestions;
+
     /** @var float the time in seconds */
     private $time;
 
     public function __construct()
     {
         $this->time = 0;
+        $this->suggestions =[];
     }
 
 
@@ -112,6 +115,17 @@ class SearchResults
     public function getRecords(): \SilverStripe\ORM\ArrayList
     {
         return $this->records;
+    }
+
+    public function getSuggestions()
+    {
+        return $this->suggestions;
+    }
+
+
+    public function setSuggestions($newSuggestions)
+    {
+        $this->suggestions = $newSuggestions;
     }
 
 

--- a/src/Extension/IndexingExtension.php
+++ b/src/Extension/IndexingExtension.php
@@ -29,38 +29,48 @@ class IndexingExtension extends DataExtension
 
     public function onBeforeWrite(): void
     {
-        parent::onBeforeWrite();
+        //parent::onBeforeWrite();
+
+        error_log('++++ IE obw ' . $this->owner->ID);
 
         $config = SiteConfig::current_site_config();
-        // * @phpstan-ignore-next-line
-        if ($config->FreeTextSearchIndexingModeInBulk !== true) {
+
+        error_log('Checking for non bulk');
+        // @phpstan-ignore-next-line
+        if ($config->FreeTextSearchIndexingModeInBulk === false) {
+            error_log('Non bulk');
             return;
         }
 
+        error_log('Setting IsDirtyFreeTextSearch to true for bulk indexing');
         // @phpstan-ignore-next-line
         $this->owner->IsDirtyFreeTextSearch = true;
+
+        // this works
+        // $this->owner->Content = 'Content from OBW';
     }
 
 
-    public function onAfterWrite(): void
+    public function onAfterWriteNOT(): void
     {
         // @phpstan-ignore-next-line
-        $this->owner->onAfterWrite();
+       // $this->owner->onAfterWrite();
+
+        error_log('++++ IE oaw' . $this->owner->ID);
+
 
         $config = SiteConfig::current_site_config();
 
+        // defer indexing to bulk
         // @phpstan-ignore-next-line
-        if ($config->FreeTextSearchIndexingModeInBulk !== false) {
+        if ($config->FreeTextSearchIndexingModeInBulk === true) {
             return;
         }
 
+        // IsDirtyFreeTextSearch flag is not used sa we are indexing immediately
         $factory = new IndexerFactory();
         $indexer = $factory->getIndexer();
 
         $indexer->index($this->owner);
-
-        // @phpstan-ignore-next-line
-        $this->owner->IsDirtyFreeTextSearch = false;
-        $this->owner->write();
     }
 }

--- a/src/Factory/IndexablePayloadMutatorFactory.php
+++ b/src/Factory/IndexablePayloadMutatorFactory.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Factory;
+
+use SilverStripe\Core\Injector\Injector;
+use Suilven\FreeTextSearch\Interfaces\IndexablePayloadMutator;
+use Suilven\FreeTextSearch\Interfaces\Searcher;
+
+class IndexablePayloadMutatorFactory
+{
+    public function getIndexablePayloadMutator(): IndexablePayloadMutator
+    {
+        return Injector::inst()->get('FreeTextIndexablePayloadMutatorImplementation');
+    }
+}

--- a/src/Helper/BulkIndexingHelper.php
+++ b/src/Helper/BulkIndexingHelper.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Helper;
+
+use League\CLImate\CLImate;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\SiteConfig\SiteConfig;
+use Suilven\FreeTextSearch\Factory\BulkIndexerFactory;
+use Suilven\FreeTextSearch\Indexes;
+
+class BulkIndexingHelper
+{
+    /**
+     * @param $indexName
+     * @param CLImate|null $climate
+     */
+    public function bulkIndex($indexName, $climate = null)
+    {
+        $indexes = new Indexes();
+        $index = $indexes->getIndex($indexName);
+
+        /** @var string $clazz */
+        $clazz = $index->getClass();
+
+
+        $startTime = \microtime(true);
+
+        if (!(is_null($climate))) {
+            $climate->border('*');
+            $climate->green()->bold('Indexing sitetree');
+            $climate->border();
+        }
+
+
+        $nDocuments = SiteTree::get()->count();
+        $config = SiteConfig::current_site_config();
+
+        // * @phpstan-ignore-next-line
+        $bulkSize = $config->BulkSize;
+        $pages = 1+\round($nDocuments / $bulkSize);
+        $progress = !is_null($climate) ? $climate->progress()->total($nDocuments) : null;
+
+        if (is_null($climate)) {
+            $climate->green('Pages: ' . $pages);
+            $climate->green()->info('Indexing ' . $nDocuments .' objects');
+        }
+
+        $climate->orange("Preparing bulk indexer");
+        $factory = new BulkIndexerFactory();
+        $bulkIndexer = $factory->getBulkIndexer();
+        $bulkIndexer->setIndex($indexName);
+
+        for ($i = 0; $i < $pages; $i++) {
+            $dataObjects = $clazz::get()->limit($bulkSize, $i*$bulkSize)->filter('ShowInSearch', true);
+            foreach ($dataObjects as $do) {
+                // @hack @todo FIX
+                if ($do->ID === 6) {
+                    continue;
+                }
+
+                // Note this adds data to the payload, does not actually indexing against the third party search engine
+                $bulkIndexer->addDataObject($do);
+            }
+
+            // index objects up to configured bulk size
+            $bulkIndexer->indexDataObjects();
+            $current = $bulkSize * ($i+1);
+            if ($current > $nDocuments) {
+                $current = $nDocuments;
+            }
+            if (!is_null($progress)) {
+                $progress->current($current);
+            }
+        }
+
+        $endTime = \microtime(true);
+        $delta = $endTime-$startTime;
+
+        $rate = \round($nDocuments / $delta, 2);
+
+        $elapsedStr = \round($delta, 2);
+
+        if (!is_null($climate)) {
+            $climate->bold()->blue()->inline("{$nDocuments}");
+            $climate->blue()->inline(' objects indexed in ');
+            $climate->bold()->blue()->inline("{$elapsedStr}");
+            $climate->blue()->inline('s, ');
+            $climate->bold()->blue()->inline("{$rate}");
+            $climate->blue(' per second ');
+        }
+
+    }
+}

--- a/src/Helper/BulkIndexingHelper.php
+++ b/src/Helper/BulkIndexingHelper.php
@@ -50,6 +50,8 @@ class BulkIndexingHelper
 
         $nDocuments = SiteTree::get()->filter($filters)->count();
 
+        error_log('N DOCUMENTS: ' . $nDocuments);
+
         if ($nDocuments > 0) {
             $config = SiteConfig::current_site_config();
 
@@ -58,7 +60,7 @@ class BulkIndexingHelper
             $pages = 1+\round($nDocuments / $bulkSize);
             $progress = !is_null($climate) ? $climate->progress()->total($nDocuments) : null;
 
-            if (is_null($climate)) {
+            if (!is_null($climate)) {
                 $climate->green('Pages: ' . $pages);
                 $climate->green()->info('Indexing ' . $nDocuments .' objects');
             }
@@ -70,11 +72,6 @@ class BulkIndexingHelper
             for ($i = 0; $i < $pages; $i++) {
                 $dataObjects = $clazz::get()->limit($bulkSize, $i*$bulkSize)->filter($filters);
                 foreach ($dataObjects as $do) {
-                    // @hack @todo FIX
-                    if ($do->ID === 6) {
-                        continue;
-                    }
-
                     // Note this adds data to the payload, does not actually indexing against the third party search engine
                     $bulkIndexer->addDataObject($do);
                 }

--- a/src/Helper/BulkIndexingHelper.php
+++ b/src/Helper/BulkIndexingHelper.php
@@ -11,7 +11,10 @@ namespace Suilven\FreeTextSearch\Helper;
 
 use League\CLImate\CLImate;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\SiteConfig\SiteConfig;
 use Suilven\FreeTextSearch\Factory\BulkIndexerFactory;
 use Suilven\FreeTextSearch\Indexes;
@@ -19,10 +22,11 @@ use Suilven\FreeTextSearch\Indexes;
 class BulkIndexingHelper
 {
     /**
-     * @param $indexName
+     * @param string $indexName
+     * @param boolean $dirty Set this to true to only index 'dirty' DataObjects, false to reindex all
      * @param CLImate|null $climate
      */
-    public function bulkIndex($indexName, $climate = null)
+    public function bulkIndex($indexName, $dirty = false, $climate = null)
     {
         $indexes = new Indexes();
         $index = $indexes->getIndex($indexName);
@@ -39,47 +43,54 @@ class BulkIndexingHelper
             $climate->border();
         }
 
-
-        $nDocuments = SiteTree::get()->count();
-        $config = SiteConfig::current_site_config();
-
-        // * @phpstan-ignore-next-line
-        $bulkSize = $config->BulkSize;
-        $pages = 1+\round($nDocuments / $bulkSize);
-        $progress = !is_null($climate) ? $climate->progress()->total($nDocuments) : null;
-
-        if (is_null($climate)) {
-            $climate->green('Pages: ' . $pages);
-            $climate->green()->info('Indexing ' . $nDocuments .' objects');
+        $filters = ['ShowInSearch' => true];
+        if ($dirty) {
+            $filters['IsDirtyFreeTextSearch'] = true;
         }
 
-        $climate->orange("Preparing bulk indexer");
-        $factory = new BulkIndexerFactory();
-        $bulkIndexer = $factory->getBulkIndexer();
-        $bulkIndexer->setIndex($indexName);
+        $nDocuments = SiteTree::get()->filter($filters)->count();
 
-        for ($i = 0; $i < $pages; $i++) {
-            $dataObjects = $clazz::get()->limit($bulkSize, $i*$bulkSize)->filter('ShowInSearch', true);
-            foreach ($dataObjects as $do) {
-                // @hack @todo FIX
-                if ($do->ID === 6) {
-                    continue;
+        if ($nDocuments > 0) {
+            $config = SiteConfig::current_site_config();
+
+            // * @phpstan-ignore-next-line
+            $bulkSize = $config->BulkSize;
+            $pages = 1+\round($nDocuments / $bulkSize);
+            $progress = !is_null($climate) ? $climate->progress()->total($nDocuments) : null;
+
+            if (is_null($climate)) {
+                $climate->green('Pages: ' . $pages);
+                $climate->green()->info('Indexing ' . $nDocuments .' objects');
+            }
+
+            $factory = new BulkIndexerFactory();
+            $bulkIndexer = $factory->getBulkIndexer();
+            $bulkIndexer->setIndex($indexName);
+
+            for ($i = 0; $i < $pages; $i++) {
+                $dataObjects = $clazz::get()->limit($bulkSize, $i*$bulkSize)->filter($filters);
+                foreach ($dataObjects as $do) {
+                    // @hack @todo FIX
+                    if ($do->ID === 6) {
+                        continue;
+                    }
+
+                    // Note this adds data to the payload, does not actually indexing against the third party search engine
+                    $bulkIndexer->addDataObject($do);
                 }
 
-                // Note this adds data to the payload, does not actually indexing against the third party search engine
-                $bulkIndexer->addDataObject($do);
-            }
-
-            // index objects up to configured bulk size
-            $bulkIndexer->indexDataObjects();
-            $current = $bulkSize * ($i+1);
-            if ($current > $nDocuments) {
-                $current = $nDocuments;
-            }
-            if (!is_null($progress)) {
-                $progress->current($current);
+                // index objects up to configured bulk size
+                $bulkIndexer->indexDataObjects();
+                $current = $bulkSize * ($i+1);
+                if ($current > $nDocuments) {
+                    $current = $nDocuments;
+                }
+                if (!is_null($progress)) {
+                    $progress->current($current);
+                }
             }
         }
+
 
         $endTime = \microtime(true);
         $delta = $endTime-$startTime;
@@ -96,6 +107,16 @@ class BulkIndexingHelper
             $climate->bold()->blue()->inline("{$rate}");
             $climate->blue(' per second ');
         }
+
+        $clazz = $index->getClass();
+        $table =     Config::inst()->get($clazz, 'table_name');
+
+
+        DB::query("UPDATE \"{$table}\" SET \"IsDirtyFreeTextSearch\" = 0");
+
+        // @todo How to get the table name from versions?
+        DB::query("UPDATE \"{$table}_Live\" SET \"IsDirtyFreeTextSearch\" = 0");
+
 
     }
 }

--- a/src/Helper/IndexingHelper.php
+++ b/src/Helper/IndexingHelper.php
@@ -48,8 +48,8 @@ class IndexingHelper
             $payload[$indice->getName()] = $indicePayload;
 
             // this halves indexing speed
-            $payload['Link'] = $dataObject->Link();
-            $payload['AbsoluteLink'] = $dataObject->AbsoluteLink();
+          //  $payload['Link'] = $dataObject->Link();
+          //  $payload['AbsoluteLink'] = $dataObject->AbsoluteLink();
         }
 
         // @todo a possible mutator, specific to different search engines, may be required here

--- a/src/Helper/IndexingHelper.php
+++ b/src/Helper/IndexingHelper.php
@@ -46,6 +46,10 @@ class IndexingHelper
                 }
             }
             $payload[$indice->getName()] = $indicePayload;
+
+            // this halves indexing speed
+            $payload['Link'] = $dataObject->Link();
+            $payload['AbsoluteLink'] = $dataObject->AbsoluteLink();
         }
 
         // @todo a possible mutator, specific to different search engines, may be required here

--- a/src/Implementation/IdentityIndexablePayloadMutator.php
+++ b/src/Implementation/IdentityIndexablePayloadMutator.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Implementation;
+
+use SilverStripe\ORM\DataObject;
+
+class IdentityIndexablePayloadMutator
+{
+
+    public function mutatePayload($payload)
+    {
+        return $payload;
+    }
+}

--- a/src/Implementation/IdentityIndexablePayloadMutator.php
+++ b/src/Implementation/IdentityIndexablePayloadMutator.php
@@ -14,8 +14,9 @@ use SilverStripe\ORM\DataObject;
 class IdentityIndexablePayloadMutator
 {
 
-    public function mutatePayload($payload)
+    public function mutatePayload($dataObjecct, $payload)
     {
+        $payload['Link'] = $dataObjecct->Link();
         return $payload;
     }
 }

--- a/src/Interfaces/IndexablePayloadMutator.php
+++ b/src/Interfaces/IndexablePayloadMutator.php
@@ -14,5 +14,5 @@ use SilverStripe\ORM\DataObject;
 interface IndexablePayloadMutator
 {
 
-    public function mutatePayload($payload);
+    public function mutatePayload($dataObject, $payload);
 }

--- a/src/Interfaces/IndexablePayloadMutator.php
+++ b/src/Interfaces/IndexablePayloadMutator.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\Interfaces;
+
+use SilverStripe\ORM\DataObject;
+
+interface IndexablePayloadMutator
+{
+
+    public function mutatePayload($payload);
+}

--- a/src/QueuedJob/BulkIndexDirtyJob.php
+++ b/src/QueuedJob/BulkIndexDirtyJob.php
@@ -9,23 +9,34 @@
 
 namespace Suilven\FreeTextSearch\QueuedJob;
 
-use SilverStripe\Forms\CheckboxField;
-use SilverStripe\Forms\DropdownField;
-use SilverStripe\Forms\NumericField;
-use SilverStripe\Forms\TextField;
-use Suilven\FreeTextSearch\Indexes;
+use Suilven\FreeTextSearch\Helper\BulkIndexingHelper;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 
 class BulkIndexDirtyJob extends AbstractQueuedJob
 {
 
-    public function getTitle()
+    // variable $indexName cannot be declared here, because serialization of the job does not store this variable
+
+    public function getTitle(): string
     {
         return 'Bulk Index Dirty DataObjects';
     }
 
-    public function process()
+    public function hyrdate($newIndexName)
     {
-        // TODO: Implement process() method.
+        $this->indexName = $newIndexName;
+    }
+
+    public function setup(): void
+    {
+        $this->totalSteps = 1;
+    }
+
+    public function process(): void
+    {
+        $helper = new BulkIndexingHelper();
+        $helper->bulkIndex($this->indexName, true);
+
+        $this->isComplete = true;
     }
 }

--- a/src/QueuedJob/BulkIndexDirtyJob.php
+++ b/src/QueuedJob/BulkIndexDirtyJob.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Created by PhpStorm.
+ * User: gordon
+ * Date: 25/3/2561
+ * Time: 17:01 น.
+ */
+
+namespace Suilven\FreeTextSearch\QueuedJob;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\TextField;
+use Suilven\FreeTextSearch\Indexes;
+use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
+
+class BulkIndexDirtyJob extends AbstractQueuedJob
+{
+
+    public function getTitle()
+    {
+        return 'Bulk Index Dirty DataObjects';
+    }
+
+    public function process()
+    {
+        // TODO: Implement process() method.
+    }
+}

--- a/src/Task/ReindexTask.php
+++ b/src/Task/ReindexTask.php
@@ -59,6 +59,6 @@ class ReindexTask extends BuildTask
         $indexName = $request->getVar('index');
 
         $helper = new BulkIndexingHelper();
-        $helper->bulkIndex($indexName, $climate);
+        $helper->bulkIndex($indexName, true, $climate);
     }
 }

--- a/src/Task/ReindexTask.php
+++ b/src/Task/ReindexTask.php
@@ -59,6 +59,6 @@ class ReindexTask extends BuildTask
         $indexName = $request->getVar('index');
 
         $helper = new BulkIndexingHelper();
-        $helper->bulkIndex($indexName, true, $climate);
+        $helper->bulkIndex($indexName, false, $climate);
     }
 }


### PR DESCRIPTION
## Description

Offload indexing optionally into a background process

## Motivation and context

Indexing one document at a time is slow, it makes more sense to index in bulk.
1) When a dataobject is saved, mark it as 'dirty' with a flag
2) Via cron, index the 'dirty' dataobjects in bulk.

Local testing showed 400 new indexed dataobjects per second when indexed in bulk, so the cron job should be minimal.
