### PR TITLE
Fix hardcoded index name queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
             php: 7.4
             env: 'INSTALLER_VERSION=4.5.x-dev PHPUNIT_TEST=1'
         -
+          - php: 7.4
+            - env: 'INSTALLER_VERSION=4.6.x-dev PHPUNIT_TEST=1'
+        -
             php: 7.4
             env: INSTALLER_VERSION=4.5 DUPLICATE_CODE_CHECK=1
         -

--- a/_config/testing.yml
+++ b/_config/testing.yml
@@ -7,8 +7,7 @@ Only:
 ---
 
 Suilven\SphinxSearch\Service\Client:
-  # Name of Docker instance on Travis
-  host: 'manticoresearch-manticore'
+  host: '127.0.0.1'
 
 # When the tests complete (successfully), if this is not set, the shutdown function is called.  Unfortunately, there
 # is no longer a test database....

--- a/_config/testing.yml
+++ b/_config/testing.yml
@@ -14,7 +14,7 @@ Suilven\SphinxSearch\Service\Client:
 # is no longer a test database....
 Symbiote\QueuedJobs\Services\QueuedJobService:
   use_shutdown_function: false
-  
+
 Suilven\FreeTextSearch\Indexes:
   indexes:
     - index:
@@ -64,3 +64,11 @@ SilverStripe\Core\Injector\Injector:
   FreeTextIndexablePayloadMutatorImplementation:
     class: Suilven\FreeTextSearch\Implementation\IdentityIndexablePayloadMutator
 
+
+Suilven\FreeTextSearch\Tests\Models\FlickrPhoto:
+  extensions:
+    - Suilven\FreeTextSearch\Extension\IndexingExtension
+
+SilverStripe\Security\Member:
+  extensions:
+    - Suilven\FreeTextSearch\Extension\IndexingExtension

--- a/src/Helper/IndexingHelper.php
+++ b/src/Helper/IndexingHelper.php
@@ -15,6 +15,36 @@ use Suilven\FreeTextSearch\Indexes;
 class IndexingHelper
 {
     /**
+     * Get a list of index names associated with the data object
+     *
+     * @return array<string> names of indexes associated with the DataObject in question
+     */
+    public function getIndexes(DataObject $dataObject): array
+    {
+        $indexes = new Indexes();
+        $indices = $indexes->getIndexes();
+
+        $result = [];
+
+        /** @var \Suilven\FreeTextSearch\Index $indice */
+        foreach ($indices as $indice) {
+            $clazz = $indice->getClass();
+            $classes = $dataObject->getClassAncestry();
+
+            foreach ($classes as $indiceClass) {
+                if ($indiceClass !== $clazz) {
+                    continue;
+                }
+
+                $result[] = $indice->getName();
+            }
+        }
+
+        return $result;
+    }
+
+
+    /**
      * Get the indexable fields for a given dataobject as an array
      *
      * @param \SilverStripe\ORM\DataObject $dataObject get the indexable fields for the provided data object

--- a/tests/Extension/IndexingExtensionTest.php
+++ b/tests/Extension/IndexingExtensionTest.php
@@ -4,12 +4,19 @@ namespace Suilven\FreeTextSearch\Tests\Extension;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DB;
+use SilverStripe\Security\Member;
 use SilverStripe\SiteConfig\SiteConfig;
 use Suilven\FreeTextSearch\Tests\Mock\Indexer;
+use Suilven\FreeTextSearch\Tests\Models\FlickrPhoto;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 
 class IndexingExtensionTest extends SapphireTest
 {
+
+    protected static $extra_dataobjects = [
+        FlickrPhoto::class,
+    ];
+
     // this will enable immediate indexing
     public function setUp(): void
     {
@@ -48,7 +55,67 @@ class IndexingExtensionTest extends SapphireTest
         $this->assertEquals('Rupert liked playing chess', $firstPagePayload['sitetree']['MenuTitle']);
         $this->assertEquals('<p>THe black queen had been taken</p>', $firstPagePayload['sitetree']['Content']);
     }
-    
+
+
+    // same as the previous test, but against a different index - it was previously hardcoded
+    public function testIndividualPhoto(): void
+    {
+        Indexer::resetIndexedPayload();
+
+        // only one job is created per index when there are dirty objects to index.  This is dealt with within the
+        // queued jobs module, in that the job parameters are identical.  One job will already be present from
+        // loading of the fixtures.  As such, clear the queue
+        DB::query('DELETE FROM "QueuedJobDescriptor"');
+
+        $this->assertEquals(0, QueuedJobDescriptor::get()->count());
+
+        $photo = new FlickrPhoto();
+        $photo->Title = 'Rupert liked playing chess';
+        $photo->Description = '<p>THe black queen had been taken</p>';
+        $photo->write();
+
+        $this->assertEquals(0, QueuedJobDescriptor::get()->count());
+
+        $payload = Indexer::getIndexedPayload();
+        $this->assertEquals(1, \sizeof($payload));
+        $firstPagePayload = $payload[0];
+        $this->assertEquals([], $firstPagePayload['sitetree']);
+        $this->assertEquals([], $firstPagePayload['members']);
+        $this->assertEquals('Rupert liked playing chess', $firstPagePayload['flickrphotos']['Title']);
+        $this->assertEquals('<p>THe black queen had been taken</p>', $firstPagePayload['flickrphotos']['Description']);
+    }
+
+
+    // same as the previous test, but against a different index - it was previously hardcoded
+    public function testIndividualMember(): void
+    {
+        Indexer::resetIndexedPayload();
+
+        // only one job is created per index when there are dirty objects to index.  This is dealt with within the
+        // queued jobs module, in that the job parameters are identical.  One job will already be present from
+        // loading of the fixtures.  As such, clear the queue
+        DB::query('DELETE FROM "QueuedJobDescriptor"');
+
+        $this->assertEquals(0, QueuedJobDescriptor::get()->count());
+
+        $member = new Member();
+        $member->FirstName = 'Gordon';
+        $member->Surname = 'Anderson';
+        $member->Email = 'gba01@mailinator.com';
+        $member->write();
+
+        $this->assertEquals(0, QueuedJobDescriptor::get()->count());
+
+        $payload = Indexer::getIndexedPayload();
+        $this->assertEquals(1, \sizeof($payload));
+        $firstPagePayload = $payload[0];
+        $this->assertEquals([], $firstPagePayload['sitetree']);
+        $this->assertEquals([], $firstPagePayload['flickrphotos']);
+        $this->assertEquals('Gordon', $firstPagePayload['members']['FirstName']);
+        $this->assertEquals('Anderson', $firstPagePayload['members']['Surname']);
+        $this->assertEquals('gba01@mailinator.com', $firstPagePayload['members']['Email']);
+    }
+
 
     public function tearDown(): void
     {


### PR DESCRIPTION
## Description

When an object was queued to be indexed, the index was hardcoded to sitetree.

## Motivation and context

This ensures that objects are indexed against their respective index.

## How has this been tested?

Local phpunit, Travis.  The indexed payloads are checked for the correct index name
