### PR TITLE
Fix index creation

### DIFF
--- a/_config/indexes.yml
+++ b/_config/indexes.yml
@@ -16,3 +16,4 @@ Suilven\FreeTextSearch\Indexes:
           - Sort
           - Created
           - LastEdited
+          - MetaDescription

--- a/src/Base/IndexCreator.php
+++ b/src/Base/IndexCreator.php
@@ -31,15 +31,10 @@ abstract class IndexCreator implements \Suilven\FreeTextSearch\Interfaces\IndexC
     protected function getFieldSpecs(string $indexName): array
     {
         $indexes = new Indexes();
-
         $index = $indexes->getIndex($indexName);
-
         $fields = [];
-
         $singleton = \singleton($index->getClass());
 
-
-        // @todo different field types
         foreach ($index->getFields() as $field) {
             $fields[] = $field;
         }

--- a/tests/Factory/IndexCreatorFactoryTest.php
+++ b/tests/Factory/IndexCreatorFactoryTest.php
@@ -13,6 +13,8 @@ class IndexCreatorFactoryTest extends SapphireTest
     public function testFactory(): void
     {
         $factory = new IndexCreatorFactory();
+
+        /** @var \Suilven\FreeTextSearch\Tests\Mock\IndexCreator $indexCreator */
         $indexCreator = $factory->getIndexCreator();
         $this->assertInstanceOf('Suilven\FreeTextSearch\Interfaces\IndexCreator', $indexCreator);
         $this->assertInstanceOf('Suilven\FreeTextSearch\Tests\Mock\IndexCreator', $indexCreator);
@@ -20,5 +22,37 @@ class IndexCreatorFactoryTest extends SapphireTest
         $indexCreator->createIndex('sitetree');
 
         $this->assertEquals('sitetree', IndexCreator::getIndexName());
+
+        $reflection = new \ReflectionClass(\get_class($indexCreator));
+        $method = $reflection->getMethod('getFieldSpecs');
+        $method->setAccessible(true);
+
+        $specs = $method->invokeArgs($indexCreator, ['sitetree']);
+        $this->assertEquals([
+            'Title' => 'Varchar',
+            'Content' => 'HTMLText',
+            'ParentID' => 'ForeignKey',
+            'MenuTitle' => 'Varchar',
+            'Sort' => 'Int',
+            'Created' => 'DBDatetime',
+            'LastEdited' => 'DBDatetime',
+            'MetaDescription' => 'Text',
+        ], $specs);
+
+        $specs = $method->invokeArgs($indexCreator, ['members']);
+        $this->assertEquals([
+            'FirstName' => 'Varchar',
+            'Surname' => 'Varchar',
+            'Email' => 'Varchar',
+        ], $specs);
+
+        $specs = $method->invokeArgs($indexCreator, ['flickrphotos']);
+        $this->assertEquals([
+            'Title' => 'Varchar',
+            'Description' => 'HTMLText',
+            'Aperture' => 'Float',
+            'ShutterSpeed' => 'Varchar',
+            'ISO' => 'Int',
+        ], $specs);
     }
 }

--- a/tests/Mock/IndexCreator.php
+++ b/tests/Mock/IndexCreator.php
@@ -12,7 +12,7 @@ class IndexCreator extends \Suilven\FreeTextSearch\Base\IndexCreator implements
 
     public function createIndex(string $indexName): void
     {
-        parent::createIndex($indexName);
+        self::$indexName = $indexName;
     }
 
 


### PR DESCRIPTION
## Description

The IndexCreator createIndex method is meaningless.  Extract code from the manticoresearch module that can be used for other search engines also

## Motivation and context

Avoid repetition.  The actual search engine implementation modules should only be about the search engine and nothing else

## How has this been tested?

Local phpunit, Travis CI
